### PR TITLE
BRUCE-6865: Fix the kafka config topic to set it odim-control-messages for intercomm messages

### DIFF
--- a/lib-utilities/common/intercomm.go
+++ b/lib-utilities/common/intercomm.go
@@ -24,12 +24,6 @@ const (
 	SubscribeEMB ControlMessage = iota
 )
 
-const (
-	// InterCommMsgQueueName is the name of the messagebus
-	// queue which is used for inter comm events
-	InterCommMsgQueueName = "ODIM-CONTROL-MESSAGES"
-)
-
 // ControlMessageData holds the control message data
 type ControlMessageData struct {
 	MessageType ControlMessage

--- a/lib-utilities/config/config.go
+++ b/lib-utilities/config/config.go
@@ -90,9 +90,9 @@ type DBConf struct {
 
 // MessageBusConf holds all message bus configurations
 type MessageBusConf struct {
-	MessageBusConfigFilePath string   `json:"MessageBusConfigFilePath"`
-	MessageBusType           string   `json:"MessageBusType"`
-	MessageBusQueue          []string `json:"MessageBusQueue"`
+	MessageBusConfigFilePath string `json:"MessageBusConfigFilePath"`
+	MessageBusType           string `json:"MessageBusType"`
+	OdimControlMessageQueue  string `json:"OdimControlMessageQueue"`
 }
 
 // KeyCertConf is for holding all security oriented configuration

--- a/lib-utilities/config/config.go
+++ b/lib-utilities/config/config.go
@@ -92,7 +92,7 @@ type DBConf struct {
 type MessageBusConf struct {
 	MessageBusConfigFilePath string `json:"MessageBusConfigFilePath"`
 	MessageBusType           string `json:"MessageBusType"`
-	OdimControlMessageQueue  string `json:"OdimControlMessageQueue"`
+	ControlMessageQueue      string `json:"OdimControlMessageQueue"`
 }
 
 // KeyCertConf is for holding all security oriented configuration

--- a/lib-utilities/config/config.go
+++ b/lib-utilities/config/config.go
@@ -92,7 +92,7 @@ type DBConf struct {
 type MessageBusConf struct {
 	MessageBusConfigFilePath string `json:"MessageBusConfigFilePath"`
 	MessageBusType           string `json:"MessageBusType"`
-	ControlMessageQueue      string `json:"OdimControlMessageQueue"`
+	OdimControlMessageQueue  string `json:"OdimControlMessageQueue"`
 }
 
 // KeyCertConf is for holding all security oriented configuration

--- a/lib-utilities/config/config_test.go
+++ b/lib-utilities/config/config_test.go
@@ -140,8 +140,8 @@ func TestSetConfiguration(t *testing.T) {
         },
        	"MessageBusConf": {
       			"MessageBusConfigFilePath": "/tmp/testFile.dat",
-	                "MessageBusType": "Kafka",
-      			"MessageBusQueue": ["REDFISH-EVENTS-TOPIC"]
+	            "MessageBusType": "Kafka",
+				"OdimControlMessageQueue":"ODIM-CONTROL-MESSAGES"
 	      },
         "FirmwareVersion": "1.0",
         "SouthBoundRequestTimeoutInSecs": 10,

--- a/lib-utilities/config/odimra_config.json
+++ b/lib-utilities/config/odimra_config.json
@@ -19,9 +19,7 @@
 	"MessageBusConf": {
 	   "MessageBusConfigFilePath": "",
 	   "MessageBusType": "Kafka",
-	   "MessageBusQueue": [
-		  "REDFISH-EVENTS-TOPIC"
-	   ]
+	   "OdimControlMessageQueue":"ODIM-CONTROL-MESSAGES"
 	},
 	"DBConf": {
 	   "Protocol": "tcp",

--- a/svc-aggregation/agmessagebus/publish.go
+++ b/svc-aggregation/agmessagebus/publish.go
@@ -28,7 +28,7 @@ import (
 
 //Publish will takes the system id,Event type and publishes the data to message bus
 func Publish(systemID, eventType, collectionType string) {
-	topicName := config.Data.MessageBusConf.ControlMessageQueue
+	topicName := config.Data.MessageBusConf.OdimControlMessageQueue
 	k, err := dc.Communicator(config.Data.MessageBusConf.MessageBusType, config.Data.MessageBusConf.MessageBusConfigFilePath, topicName)
 	if err != nil {
 		l.Log.Error("Unable to connect to " + config.Data.MessageBusConf.MessageBusType + " " + err.Error())
@@ -77,7 +77,7 @@ func Publish(systemID, eventType, collectionType string) {
 
 // PublishCtrlMsg publishes ODIM control messages to the message bus
 func PublishCtrlMsg(msgType common.ControlMessage, msg interface{}) error {
-	topicName := config.Data.MessageBusConf.ControlMessageQueue
+	topicName := config.Data.MessageBusConf.OdimControlMessageQueue
 	conn, err := dc.Communicator(config.Data.MessageBusConf.MessageBusType, config.Data.MessageBusConf.MessageBusConfigFilePath, topicName)
 	if err != nil {
 		return fmt.Errorf("failed to get kafka connection: %s", err.Error())

--- a/svc-aggregation/agmessagebus/publish.go
+++ b/svc-aggregation/agmessagebus/publish.go
@@ -28,7 +28,7 @@ import (
 
 //Publish will takes the system id,Event type and publishes the data to message bus
 func Publish(systemID, eventType, collectionType string) {
-	topicName := config.Data.MessageBusConf.OdimControlMessageQueue
+	topicName := config.Data.MessageBusConf.ControlMessageQueue
 	k, err := dc.Communicator(config.Data.MessageBusConf.MessageBusType, config.Data.MessageBusConf.MessageBusConfigFilePath, topicName)
 	if err != nil {
 		l.Log.Error("Unable to connect to " + config.Data.MessageBusConf.MessageBusType + " " + err.Error())
@@ -77,7 +77,7 @@ func Publish(systemID, eventType, collectionType string) {
 
 // PublishCtrlMsg publishes ODIM control messages to the message bus
 func PublishCtrlMsg(msgType common.ControlMessage, msg interface{}) error {
-	topicName := config.Data.MessageBusConf.OdimControlMessageQueue
+	topicName := config.Data.MessageBusConf.ControlMessageQueue
 	conn, err := dc.Communicator(config.Data.MessageBusConf.MessageBusType, config.Data.MessageBusConf.MessageBusConfigFilePath, topicName)
 	if err != nil {
 		return fmt.Errorf("failed to get kafka connection: %s", err.Error())

--- a/svc-aggregation/agmessagebus/publish.go
+++ b/svc-aggregation/agmessagebus/publish.go
@@ -28,7 +28,7 @@ import (
 
 //Publish will takes the system id,Event type and publishes the data to message bus
 func Publish(systemID, eventType, collectionType string) {
-	topicName := config.Data.MessageBusConf.MessageBusQueue[0]
+	topicName := config.Data.MessageBusConf.OdimControlMessageQueue
 	k, err := dc.Communicator(config.Data.MessageBusConf.MessageBusType, config.Data.MessageBusConf.MessageBusConfigFilePath, topicName)
 	if err != nil {
 		l.Log.Error("Unable to connect to " + config.Data.MessageBusConf.MessageBusType + " " + err.Error())
@@ -77,7 +77,7 @@ func Publish(systemID, eventType, collectionType string) {
 
 // PublishCtrlMsg publishes ODIM control messages to the message bus
 func PublishCtrlMsg(msgType common.ControlMessage, msg interface{}) error {
-	topicName := config.Data.MessageBusConf.MessageBusQueue[0]
+	topicName := config.Data.MessageBusConf.OdimControlMessageQueue
 	conn, err := dc.Communicator(config.Data.MessageBusConf.MessageBusType, config.Data.MessageBusConf.MessageBusConfigFilePath, topicName)
 	if err != nil {
 		return fmt.Errorf("failed to get kafka connection: %s", err.Error())

--- a/svc-events/main.go
+++ b/svc-events/main.go
@@ -101,7 +101,7 @@ func main() {
 	go evcommon.TrackConfigFileChanges()
 
 	// Subscribe to intercomm messagebus queue
-	go consumer.SubscribeCtrlMsgQueue(config.Data.MessageBusConf.OdimControlMessageQueue)
+	go consumer.SubscribeCtrlMsgQueue(config.Data.MessageBusConf.ControlMessageQueue)
 
 	// Subscribe to EMBs of all the available plugins
 	startUPInterface := evcommon.StartUpInteraface{

--- a/svc-events/main.go
+++ b/svc-events/main.go
@@ -101,7 +101,7 @@ func main() {
 	go evcommon.TrackConfigFileChanges()
 
 	// Subscribe to intercomm messagebus queue
-	go consumer.SubscribeCtrlMsgQueue(config.Data.MessageBusConf.ControlMessageQueue)
+	go consumer.SubscribeCtrlMsgQueue(config.Data.MessageBusConf.OdimControlMessageQueue)
 
 	// Subscribe to EMBs of all the available plugins
 	startUPInterface := evcommon.StartUpInteraface{

--- a/svc-events/main.go
+++ b/svc-events/main.go
@@ -101,7 +101,7 @@ func main() {
 	go evcommon.TrackConfigFileChanges()
 
 	// Subscribe to intercomm messagebus queue
-	go consumer.SubscribeCtrlMsgQueue(config.Data.MessageBusConf.MessageBusQueue[0])
+	go consumer.SubscribeCtrlMsgQueue(config.Data.MessageBusConf.OdimControlMessageQueue)
 
 	// Subscribe to EMBs of all the available plugins
 	startUPInterface := evcommon.StartUpInteraface{

--- a/svc-task/tmessagebus/publish.go
+++ b/svc-task/tmessagebus/publish.go
@@ -27,7 +27,7 @@ import (
 
 //Publish will takes the taskURI, messageID, Event type and publishes the data to message bus
 func Publish(taskURI, messageID, eventType, taskMessage string) {
-	topicName := config.Data.MessageBusConf.OdimControlMessageQueue
+	topicName := config.Data.MessageBusConf.ControlMessageQueue
 	k, err := dc.Communicator(config.Data.MessageBusConf.MessageBusType, config.Data.MessageBusConf.MessageBusConfigFilePath, topicName)
 	if err != nil {
 		l.Log.Error("Unable to connect to " + config.Data.MessageBusConf.MessageBusType + " " + err.Error())

--- a/svc-task/tmessagebus/publish.go
+++ b/svc-task/tmessagebus/publish.go
@@ -27,7 +27,7 @@ import (
 
 //Publish will takes the taskURI, messageID, Event type and publishes the data to message bus
 func Publish(taskURI, messageID, eventType, taskMessage string) {
-	topicName := config.Data.MessageBusConf.ControlMessageQueue
+	topicName := config.Data.MessageBusConf.OdimControlMessageQueue
 	k, err := dc.Communicator(config.Data.MessageBusConf.MessageBusType, config.Data.MessageBusConf.MessageBusConfigFilePath, topicName)
 	if err != nil {
 		l.Log.Error("Unable to connect to " + config.Data.MessageBusConf.MessageBusType + " " + err.Error())

--- a/svc-task/tmessagebus/publish.go
+++ b/svc-task/tmessagebus/publish.go
@@ -27,7 +27,7 @@ import (
 
 //Publish will takes the taskURI, messageID, Event type and publishes the data to message bus
 func Publish(taskURI, messageID, eventType, taskMessage string) {
-	topicName := config.Data.MessageBusConf.MessageBusQueue[0]
+	topicName := config.Data.MessageBusConf.OdimControlMessageQueue
 	k, err := dc.Communicator(config.Data.MessageBusConf.MessageBusType, config.Data.MessageBusConf.MessageBusConfigFilePath, topicName)
 	if err != nil {
 		l.Log.Error("Unable to connect to " + config.Data.MessageBusConf.MessageBusType + " " + err.Error())


### PR DESCRIPTION
Fix the kafka topic config for odim control messages instead of Redfish-event-topic and keep the config parameter to string withing index
