### PR TITLE
Fixing the fatal issues which were caused due to empty context sent to TaskUpdate

### DIFF
--- a/svc-aggregation/system/addaggregationsource.go
+++ b/svc-aggregation/system/addaggregationsource.go
@@ -43,7 +43,7 @@ func (e *ExternalInterface) AddAggregationSource(ctx context.Context, taskID str
 		l.LogWithFields(ctx).Error(errMsg)
 		return common.GeneralError(http.StatusInternalServerError, response.InternalError, errMsg, nil, nil)
 	}
-	taskInfo := &common.TaskUpdateInfo{TaskID: taskID, TargetURI: targetURI, UpdateTask: e.UpdateTask, TaskRequest: string(req.RequestBody)}
+	taskInfo := &common.TaskUpdateInfo{Context: ctx, TaskID: taskID, TargetURI: targetURI, UpdateTask: e.UpdateTask, TaskRequest: string(req.RequestBody)}
 	// parsing the request
 	var aggregationSourceRequest AggregationSource
 	err = json.Unmarshal(req.RequestBody, &aggregationSourceRequest)

--- a/svc-aggregation/system/addcompute.go
+++ b/svc-aggregation/system/addcompute.go
@@ -39,7 +39,7 @@ func (e *ExternalInterface) addCompute(ctx context.Context, taskID, targetURI, p
 	l.LogWithFields(ctx).Info("started adding system with manager address " + addResourceRequest.ManagerAddress +
 		" using plugin id: " + pluginID)
 
-	taskInfo := &common.TaskUpdateInfo{TaskID: taskID, TargetURI: targetURI, UpdateTask: e.UpdateTask, TaskRequest: pluginContactRequest.TaskRequest}
+	taskInfo := &common.TaskUpdateInfo{Context: ctx, TaskID: taskID, TargetURI: targetURI, UpdateTask: e.UpdateTask, TaskRequest: pluginContactRequest.TaskRequest}
 
 	var task = fillTaskData(taskID, targetURI, pluginContactRequest.TaskRequest, resp, common.Running, common.OK, percentComplete, http.MethodPost)
 

--- a/svc-aggregation/system/addplugin.go
+++ b/svc-aggregation/system/addplugin.go
@@ -34,7 +34,7 @@ import (
 
 func (e *ExternalInterface) addPluginData(ctx context.Context, req AddResourceRequest, taskID, targetURI string, pluginContactRequest getResourceRequest, queueList []string, cmVariants connectionMethodVariants) (response.RPC, string, []byte) {
 	var resp response.RPC
-	taskInfo := &common.TaskUpdateInfo{TaskID: taskID, TargetURI: targetURI, UpdateTask: e.UpdateTask, TaskRequest: pluginContactRequest.TaskRequest}
+	taskInfo := &common.TaskUpdateInfo{Context: ctx, TaskID: taskID, TargetURI: targetURI, UpdateTask: e.UpdateTask, TaskRequest: pluginContactRequest.TaskRequest}
 
 	if !(cmVariants.PreferredAuthType == "BasicAuth" || cmVariants.PreferredAuthType == "XAuthToken") {
 		errMsg := "error: incorrect request property value for PreferredAuthType"

--- a/svc-aggregation/system/aggregate.go
+++ b/svc-aggregation/system/aggregate.go
@@ -49,7 +49,7 @@ var (
 	DeleteAggregateSubscription = deleteAggregateSubscription
 )
 
-//ResetRequest is struct for reset of elements of an aggregate
+// ResetRequest is struct for reset of elements of an aggregate
 type ResetRequest struct {
 	BatchSize                    int    `json:"BatchSize"`
 	DelayBetweenBatchesInSeconds int    `json:"DelayBetweenBatchesInSeconds"`
@@ -131,7 +131,7 @@ func validateElements(elements []agmodel.OdataID) (int32, error) {
 	return http.StatusOK, nil
 }
 
-//check if the elements have duplicate element
+// check if the elements have duplicate element
 func checkDuplicateElements(elelments []agmodel.OdataID) bool {
 	duplicate := make(map[string]int)
 	for _, element := range elelments {
@@ -181,7 +181,7 @@ func (e *ExternalInterface) GetAllAggregates(ctx context.Context, req *aggregato
 }
 
 // GetAggregate is the handler for getting an aggregate
-//if the aggregate id is present then return aggregate details else return an error.
+// if the aggregate id is present then return aggregate details else return an error.
 func (e *ExternalInterface) GetAggregate(ctx context.Context, req *aggregatorproto.AggregatorRequest) response.RPC {
 	aggregate, err := agmodel.GetAggregate(req.URL)
 	if err != nil {
@@ -458,7 +458,7 @@ func (e *ExternalInterface) ResetElementsOfAggregate(ctx context.Context, taskID
 	targetURI := req.URL
 	percentComplete = 0
 
-	taskInfo := &common.TaskUpdateInfo{TaskID: taskID, TargetURI: targetURI, UpdateTask: e.UpdateTask, TaskRequest: string(req.RequestBody)}
+	taskInfo := &common.TaskUpdateInfo{Context: ctx, TaskID: taskID, TargetURI: targetURI, UpdateTask: e.UpdateTask, TaskRequest: string(req.RequestBody)}
 
 	var resetRequest ResetRequest
 	if err := json.Unmarshal(req.RequestBody, &resetRequest); err != nil {
@@ -616,7 +616,7 @@ func (e *ExternalInterface) resetSystem(ctx context.Context, taskID, reqBody str
 	}
 	systemID := element[strings.LastIndexAny(element, "/")+1:]
 	var targetURI = element
-	taskInfo := &common.TaskUpdateInfo{TaskID: subTaskID, TargetURI: targetURI, UpdateTask: e.UpdateTask, TaskRequest: reqBody}
+	taskInfo := &common.TaskUpdateInfo{Context: ctx, TaskID: subTaskID, TargetURI: targetURI, UpdateTask: e.UpdateTask, TaskRequest: reqBody}
 	data := strings.SplitN(systemID, ".", 2)
 	if len(data) <= 1 {
 		subTaskChan <- http.StatusNotFound
@@ -761,7 +761,7 @@ func (e *ExternalInterface) SetDefaultBootOrderElementsOfAggregate(ctx context.C
 	var percentComplete int32 = 100
 	targetURI := req.URL
 
-	taskInfo := &common.TaskUpdateInfo{TaskID: taskID, TargetURI: targetURI, UpdateTask: e.UpdateTask}
+	taskInfo := &common.TaskUpdateInfo{Context: ctx, TaskID: taskID, TargetURI: targetURI, UpdateTask: e.UpdateTask}
 
 	reqBody, err := json.Marshal(req)
 	if err != nil {

--- a/svc-aggregation/system/bootorder.go
+++ b/svc-aggregation/system/bootorder.go
@@ -43,7 +43,7 @@ type AggregationSetDefaultBootOrderRequest struct {
 	Systems []OdataID `json:"Systems"`
 }
 
-//OdataID struct definition for @odata.id
+// OdataID struct definition for @odata.id
 type OdataID struct {
 	OdataID string `json:"@odata.id"`
 }
@@ -54,7 +54,7 @@ func (e *ExternalInterface) SetDefaultBootOrder(ctx context.Context, taskID stri
 	var percentComplete int32
 	targetURI := "/redfish/v1/AggregationService/Actions/AggregationService.SetDefaultBootOrder"
 
-	taskInfo := &common.TaskUpdateInfo{TaskID: taskID, TargetURI: targetURI, UpdateTask: e.UpdateTask, TaskRequest: string(req.RequestBody)}
+	taskInfo := &common.TaskUpdateInfo{Context: ctx, TaskID: taskID, TargetURI: targetURI, UpdateTask: e.UpdateTask, TaskRequest: string(req.RequestBody)}
 
 	var setOrderReq AggregationSetDefaultBootOrderRequest
 	if err := json.Unmarshal(req.RequestBody, &setOrderReq); err != nil {
@@ -169,7 +169,7 @@ func (e *ExternalInterface) collectAndSetDefaultOrder(ctx context.Context, taskI
 		subTaskID = strArray[len(strArray)-1]
 	}
 
-	taskInfo := &common.TaskUpdateInfo{TaskID: subTaskID, TargetURI: serverURI, UpdateTask: e.UpdateTask, TaskRequest: reqJSON}
+	taskInfo := &common.TaskUpdateInfo{Context: ctx, TaskID: subTaskID, TargetURI: serverURI, UpdateTask: e.UpdateTask, TaskRequest: reqJSON}
 
 	var percentComplete int32
 	uuid, systemID, err := getIDsFromURI(serverURI)

--- a/svc-aggregation/system/reset.go
+++ b/svc-aggregation/system/reset.go
@@ -71,7 +71,7 @@ func (e *ExternalInterface) Reset(ctx context.Context, taskID string, sessionUse
 	targetURI := "/redfish/v1/AggregationService/Actions/AggregationService.Reset/" // this will removed later and passed as input param in req struct
 	percentComplete = 0
 
-	taskInfo := &common.TaskUpdateInfo{TaskID: taskID, TargetURI: targetURI, UpdateTask: e.UpdateTask, TaskRequest: string(req.RequestBody)}
+	taskInfo := &common.TaskUpdateInfo{Context: ctx, TaskID: taskID, TargetURI: targetURI, UpdateTask: e.UpdateTask, TaskRequest: string(req.RequestBody)}
 
 	var resetRequest AggregationResetRequest
 	if err := json.Unmarshal(req.RequestBody, &resetRequest); err != nil {
@@ -210,7 +210,7 @@ func (e *ExternalInterface) aggregateSystems(ctx context.Context, requestType, u
 	} else {
 		subTaskID = strArray[len(strArray)-1]
 	}
-	taskInfo := &common.TaskUpdateInfo{TaskID: subTaskID, TargetURI: url, UpdateTask: e.UpdateTask, TaskRequest: reqBody}
+	taskInfo := &common.TaskUpdateInfo{Context: ctx, TaskID: subTaskID, TargetURI: url, UpdateTask: e.UpdateTask, TaskRequest: reqBody}
 	aggregate, err1 := agmodel.GetAggregate(url)
 	if err1 != nil {
 		percentComplete = 100


### PR DESCRIPTION
Fixing the fatal issues which were caused due to empty context sent to TaskUpdate