### PR TITLE
Fixing the nil parameters in logging during internal RPC calls

### DIFF
--- a/lib-utilities/services/auth.go
+++ b/lib-utilities/services/auth.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	authproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/auth"
 	sessionproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/session"
 	"github.com/ODIM-Project/ODIM/lib-utilities/response"
@@ -38,8 +39,10 @@ func IsAuthorized(ctx context.Context, sessionToken string, privileges, oemPrivi
 	}
 	defer conn.Close()
 	asService := authproto.NewAuthorizationClient(conn)
+	ctxt := common.CreateNewRequestContext(ctx)
+	ctxt = common.CreateMetadata(ctxt)
 	response, err := asService.IsAuthorized(
-		ctx,
+		ctxt,
 		&authproto.AuthRequest{
 			SessionToken:  sessionToken,
 			Privileges:    privileges,
@@ -65,8 +68,10 @@ func GetSessionUserName(ctx context.Context, sessionToken string) (string, error
 	}
 	defer conn.Close()
 	asService := sessionproto.NewSessionClient(conn)
+	ctxt := common.CreateNewRequestContext(ctx)
+	ctxt = common.CreateMetadata(ctxt)
 	response, err := asService.GetSessionUserName(
-		ctx,
+		ctxt,
 		&sessionproto.SessionRequest{
 			SessionToken: sessionToken,
 		},
@@ -85,8 +90,10 @@ func GetSessionUserRoleID(ctx context.Context, sessionToken string) (string, err
 	}
 	defer conn.Close()
 	asService := sessionproto.NewSessionClient(conn)
+	ctxt := common.CreateNewRequestContext(ctx)
+	ctxt = common.CreateMetadata(ctxt)
 	response, err := asService.GetSessionUserRoleID(
-		ctx,
+		ctxt,
 		&sessionproto.SessionRequest{
 			SessionToken: sessionToken,
 		},

--- a/lib-utilities/services/eventsubscription.go
+++ b/lib-utilities/services/eventsubscription.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	eventsproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/events"
 )
 
@@ -29,7 +30,9 @@ func SubscribeToEMB(ctx context.Context, pluginID string, queueList []string) er
 	}
 	defer conn.Close()
 	events := eventsproto.NewEventsClient(conn)
-	_, err := events.SubscribeEMB(ctx, &eventsproto.SubscribeEMBRequest{
+	ctxt := common.CreateNewRequestContext(ctx)
+	ctxt = common.CreateMetadata(ctxt)
+	_, err := events.SubscribeEMB(ctxt, &eventsproto.SubscribeEMBRequest{
 		PluginID:     pluginID,
 		EMBQueueName: queueList,
 	})
@@ -40,7 +43,7 @@ func SubscribeToEMB(ctx context.Context, pluginID string, queueList []string) er
 }
 
 // DeleteSubscription  calls the event service and delete all subscription realated to that server
-func DeleteSubscription(uuid string) (*eventsproto.EventSubResponse, error) {
+func DeleteSubscription(ctx context.Context, uuid string) (*eventsproto.EventSubResponse, error) {
 	var resp eventsproto.EventSubResponse
 	req := eventsproto.EventRequest{
 		UUID: uuid,
@@ -51,6 +54,7 @@ func DeleteSubscription(uuid string) (*eventsproto.EventSubResponse, error) {
 	}
 	defer conn.Close()
 	events := eventsproto.NewEventsClient(conn)
-
-	return events.DeleteEventSubscription(context.TODO(), &req)
+	ctxt := common.CreateNewRequestContext(ctx)
+	ctxt = common.CreateMetadata(ctxt)
+	return events.DeleteEventSubscription(ctxt, &req)
 }

--- a/svc-aggregation/rpc/common_test.go
+++ b/svc-aggregation/rpc/common_test.go
@@ -118,7 +118,7 @@ func deleteSystemforTest(key string) *errors.Error {
 	return nil
 }
 
-func mockDeleteSubscription(uuid string) (*eventsproto.EventSubResponse, error) {
+func mockDeleteSubscription(ctx context.Context, uuid string) (*eventsproto.EventSubResponse, error) {
 	if uuid == "/redfish/v1/systems/delete-subscription-error.1" {
 		return nil, fmt.Errorf("error while trying to delete event subcription")
 	} else if uuid == "/redfish/v1/systems/unexpected-statuscode.1" {

--- a/svc-aggregation/system/common.go
+++ b/svc-aggregation/system/common.go
@@ -90,7 +90,7 @@ type ExternalInterface struct {
 	DecryptPassword          func([]byte) ([]byte, error)
 	DeleteComputeSystem      func(int, string) *errors.Error
 	DeleteSystem             func(string) *errors.Error
-	DeleteEventSubscription  func(string) (*eventsproto.EventSubResponse, error)
+	DeleteEventSubscription  func(context.Context, string) (*eventsproto.EventSubResponse, error)
 	EventNotification        func(context.Context, string, string, string)
 	GetAllKeysFromTable      func(context.Context, string) ([]string, error)
 	GetConnectionMethod      func(context.Context, string) (agmodel.ConnectionMethod, *errors.Error)

--- a/svc-aggregation/system/deleteaggregationsource.go
+++ b/svc-aggregation/system/deleteaggregationsource.go
@@ -416,7 +416,7 @@ func (e *ExternalInterface) deleteCompute(ctx context.Context, key string, index
 		}
 	}()
 	// Delete Subscription on odimra and also on device
-	subResponse, err := e.DeleteEventSubscription(key)
+	subResponse, err := e.DeleteEventSubscription(ctx, key)
 	if err != nil && subResponse == nil {
 		errMsg := fmt.Sprintf("error while trying to delete subscriptions: %v", err)
 		l.LogWithFields(ctx).Error(errMsg)

--- a/svc-aggregation/system/deleteaggregationsource_test.go
+++ b/svc-aggregation/system/deleteaggregationsource_test.go
@@ -65,7 +65,7 @@ func deleteSystemforTest(key string) *errors.Error {
 	return nil
 }
 
-func mockDeleteSubscription(uuid string) (*eventsproto.EventSubResponse, error) {
+func mockDeleteSubscription(ctx context.Context, uuid string) (*eventsproto.EventSubResponse, error) {
 	if uuid == "/redfish/v1/Systems/ef83e569-7336-492a-aaee-31c02d9db832.1" {
 		return nil, fmt.Errorf("error while trying to delete event subcription")
 	} else if uuid == "/redfish/v1/Systems/unexpected-statuscode.1" {

--- a/svc-events/events/publishevttosubscriber.go
+++ b/svc-events/events/publishevttosubscriber.go
@@ -380,7 +380,9 @@ func (e *ExternalInterfaces) addFabricRPCCall(ctx context.Context, origin, addre
 	}
 	defer conn.Close()
 	fab := fabricproto.NewFabricsClient(conn)
-	_, err = fab.AddFabric(context.TODO(), &fabricproto.AddFabricRequest{
+	ctxt := common.CreateNewRequestContext(ctx)
+	ctxt = common.CreateMetadata(ctxt)
+	_, err = fab.AddFabric(ctxt, &fabricproto.AddFabricRequest{
 		OriginResource: origin,
 		Address:        address,
 	})
@@ -402,7 +404,9 @@ func (e *ExternalInterfaces) removeFabricRPCCall(ctx context.Context, origin, ad
 	}
 	defer conn.Close()
 	fab := fabricproto.NewFabricsClient(conn)
-	_, err = fab.RemoveFabric(context.TODO(), &fabricproto.AddFabricRequest{
+	ctxt := common.CreateNewRequestContext(ctx)
+	ctxt = common.CreateMetadata(ctxt)
+	_, err = fab.RemoveFabric(ctxt, &fabricproto.AddFabricRequest{
 		OriginResource: origin,
 		Address:        address,
 	})


### PR DESCRIPTION
Fixing the nil parameters in logging during internal RPC calls